### PR TITLE
Add option to prevent tokenizing on didBeginEditing

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -273,7 +273,16 @@ public class KSTokenView: UIView {
          }
       }
    }
-   
+
+   /// default is true. When false, the token field will not blank or tokenize when editing begins.
+   public var tokenizeOnDidBeginEditing: Bool = true {
+      didSet {
+         if (oldValue != tokenizeOnDidBeginEditing) {
+            _updateTokenField()
+         }
+      }
+   }
+
    /// default is true. When resignFirstResponder is called tokens are removed and description is displayed.
    public var removesTokensOnEndEditing: Bool = true {
       didSet {
@@ -656,7 +665,9 @@ public class KSTokenView: UIView {
    //
    func tokenFieldDidBeginEditing(tokenField: KSTokenField) {
       delegate?.tokenViewDidBeginEditing?(self)
-      tokenField.tokenize()
+      if tokenizeOnDidBeginEditing {
+         tokenField.tokenize()
+      }
       if (minimumCharactersToSearch == 0) {
          _startSearchWithString("")
       }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 pod 'KSTokenView', '~> 2.4'
-``` 
+```
 
 2. Install the pod(s) by running `pod install`.
 
@@ -135,6 +135,9 @@ tokenView.seperatorText = ", "
 /// default is 0.25.
 tokenView.animateDuration = 0.25
 
+/// default is true. When false, the token field will not blank or tokenize when editing begins.
+tokenView.tokenizeOnDidBeginEditing = false
+
 /// default is true. When resignFirstResponder is called tokens are removed and description is displayed.
 tokenView.removesTokensOnEndEditing = true
 
@@ -165,4 +168,4 @@ tokenView.tokenizingCharacters = [","]
 See example projects for detail.
 
 ## License
-This code is distributed under the terms and conditions of the [MIT license](LICENSE). 
+This code is distributed under the terms and conditions of the [MIT license](LICENSE).


### PR DESCRIPTION
This should not break existing behaviour.

The benefit of exposing this option is that people who use this library
can now control whether the tokenField gets blanked on being clicked.

(for example, when the user tries to move the cursor in the text field,
the default behavior is for the field to be blanked)