### PR TITLE
Add option to prevent blanking the text field on begin edit

### DIFF
--- a/KSTokenView/KSTokenField.swift
+++ b/KSTokenView/KSTokenField.swift
@@ -318,7 +318,7 @@ public class KSTokenField: UITextField {
       }
    }
    
-   
+
    //MARK: - Layout
    /*
    **************************** Layout ****************************
@@ -327,7 +327,7 @@ public class KSTokenField: UITextField {
    /**
    Untokenzies the layout
    */
-   func untokenize() {
+    func untokenize() {
       if (!_removesTokensOnEndEditing) {
          return
       }
@@ -343,12 +343,12 @@ public class KSTokenField: UITextField {
    /**
    Tokenizes the layout
    */
-   func tokenize() {
+   func tokenize(shouldUpdateText: Bool = true) {
       _state = .Opened
       for token: KSToken in tokens {
          _insertToken(token, shouldLayout: false)
       }
-      updateLayout()
+      updateLayout(shouldUpdateText)
    }
    
    /**
@@ -562,7 +562,7 @@ public class KSTokenField: UITextField {
       case .Opened:
          text = KSTextEmpty
          break
-         
+
       case .Closed:
          if tokens.count == 0 {
             text = KSTextEmpty

--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -273,7 +273,16 @@ public class KSTokenView: UIView {
          }
       }
    }
-   
+
+   /// default is true. When false, the token field will not blank when editing begins.
+   public var blankTextFieldOnStartEditing: Bool = true {
+      didSet {
+         if (oldValue != blankTextFieldOnStartEditing) {
+            _updateTokenField()
+         }
+      }
+   }
+
    /// default is true. When resignFirstResponder is called tokens are removed and description is displayed.
    public var removesTokensOnEndEditing: Bool = true {
       didSet {
@@ -656,7 +665,8 @@ public class KSTokenView: UIView {
    //
    func tokenFieldDidBeginEditing(tokenField: KSTokenField) {
       delegate?.tokenViewDidBeginEditing?(self)
-      tokenField.tokenize()
+      tokenField.tokenize(blankTextFieldOnStartEditing)
+
       if (minimumCharactersToSearch == 0) {
          _startSearchWithString("")
       }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 pod 'KSTokenView', '~> 2.4'
-``` 
+```
 
 2. Install the pod(s) by running `pod install`.
 
@@ -135,6 +135,9 @@ tokenView.seperatorText = ", "
 /// default is 0.25.
 tokenView.animateDuration = 0.25
 
+/// default is true. When false, the token field will not blank when editing begins.
+tokenView.blankTextFieldOnStartEditing = true
+
 /// default is true. When resignFirstResponder is called tokens are removed and description is displayed.
 tokenView.removesTokensOnEndEditing = true
 
@@ -165,4 +168,4 @@ tokenView.tokenizingCharacters = [","]
 See example projects for detail.
 
 ## License
-This code is distributed under the terms and conditions of the [MIT license](LICENSE). 
+This code is distributed under the terms and conditions of the [MIT license](LICENSE).


### PR DESCRIPTION
This should not break existing behaviour.

The benefit of exposing this option is that people who use this library
can now control whether the tokenField gets blanked on being clicked.

(for example, when the user tries to move the cursor in the text field,
the default behavior was/is for the field to be blanked)